### PR TITLE
Mention runtime MCP enforcement with Armorer Guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ A lower score does NOT mean the server has bugs or is malicious. It means an AI 
 - **Risky (20-49):** Large attack surface. Requires strict sandboxing and human oversight.
 - **Dangerous (< 20):** Critical security concerns. Not recommended for automated use.
 
+Scores are a preflight signal. For runtime enforcement, tools such as
+[Armorer Guard](https://github.com/ArmorerLabs/Armorer-Guard) can wrap stdio
+MCP servers with a local proxy and inspect `tools/call` arguments for prompt
+injection, credential disclosure, exfiltration, and destructive action risk
+before the server executes the call.
+
 ## Legend
 
 | Symbol | Meaning |


### PR DESCRIPTION
Adds a short note that preflight MCP security scores can be complemented with runtime enforcement.

Armorer Guard is listed as one example because it can wrap stdio MCP servers with a local proxy and inspect `tools/call` arguments for prompt injection, credential disclosure, exfiltration, and destructive action risk before execution.

I kept this as a small explanatory note rather than adding Armorer Guard as a scanned MCP server, since it is a runtime proxy/guard rather than a normal MCP server catalog entry.